### PR TITLE
Enable strictTemplates in angular compiler

### DIFF
--- a/src/app/components/data-cards/card-list/card-list.component.ts
+++ b/src/app/components/data-cards/card-list/card-list.component.ts
@@ -1,6 +1,6 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {animate, keyframes, query, stagger, style, transition, trigger} from "@angular/animations";
-import { ICategory, IDataset } from 'src/app/shared/api/api';
+import { ICategory, IDatasetSummary } from 'src/app/shared/api/api';
 
 @Component({
   selector: 'app-card-list',
@@ -24,7 +24,7 @@ import { ICategory, IDataset } from 'src/app/shared/api/api';
 export class CardListComponent implements OnInit {
 
   @Input()
-  dataCards: IDataset[];
+  dataCards: IDatasetSummary[];
   categories: ICategory[];
 
   constructor() { }

--- a/src/app/components/data-cards/data-card/data-card.component.ts
+++ b/src/app/components/data-cards/data-card/data-card.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, OnInit} from '@angular/core';
-import { IDataset } from 'src/app/shared/api/api';
+import { IDatasetSummary } from 'src/app/shared/api/api';
 import { GetDatasetStatusName } from 'src/app/shared/constants';
 import {UserHandlerService} from "../../../shared/user/user-handler.service";
 
@@ -11,7 +11,7 @@ import {UserHandlerService} from "../../../shared/user/user-handler.service";
 export class DataCardComponent {
 
   @Input('card')
-  card: IDataset;
+  card: IDatasetSummary;
   userHasDataStewardRole$ = this.userHandlerService.userHasDataStewardRole$;
 
   constructor(private userHandlerService: UserHandlerService) { }

--- a/src/app/components/transformation-selector/transformation-selector.component.html
+++ b/src/app/components/transformation-selector/transformation-selector.component.html
@@ -4,7 +4,7 @@
              [hideSelected]="true"
              placeholder="{{'dataSteward.meta.transformation.sourceDataSetsPlaceholder' | translate}}"
              [ngClass]="{'filled': dataSetTransformation.sourceDatasets}"
-             multiple="true"
+             [multiple]="true"
              bindLabel="name"
              (change)="onDataChange()"
              [(ngModel)]="dataSetTransformation.sourceDatasets">

--- a/src/app/pages/data-steward/data-meta/data-meta.component.html
+++ b/src/app/pages/data-steward/data-meta/data-meta.component.html
@@ -5,7 +5,7 @@
              [hideSelected]="true"
              placeholder="{{'dataSteward.meta.category.addToCategory' | translate}}"
              [ngClass]="{'filled': data.categories}"
-             multiple="true"
+             [multiple]="true"
              bindLabel="name"
              (change)="onDataChange()"
              [(ngModel)]="data.categories">

--- a/src/app/pages/details-page/details-page.component.html
+++ b/src/app/pages/details-page/details-page.component.html
@@ -18,10 +18,10 @@
 
     <section class="details__section">
       <h2> {{"details.transformation" | translate}} </h2>
-      <div *ngIf="dataHandlerService.currentTransformation">
-        {{dataHandlerService.currentTransformation.description}}
+      <div *ngIf="(currentTransformation$ | async) as currentTransformation">
+        {{currentTransformation.description}}
       </div>
-      <div *ngIf="!dataHandlerService.currentTransformation">
+      <div *ngIf="!(currentTransformation$ | async)">
         {{'details.sourceData' | translate}}
       </div>
     </section>

--- a/src/app/pages/details-page/details-page.component.ts
+++ b/src/app/pages/details-page/details-page.component.ts
@@ -31,6 +31,7 @@ export class DetailsPageComponent implements OnInit, OnDestroy {
   currentTransformationDescription = '';
   userHasDataStewardRole$ = this.userHandlerService.userHasDataStewardRole$;
   oboToken$ = this.userHandlerService.oboToken$;
+  currentTransformation$ = this.dataHandlerService.currentTransformation$;
 
   constructor(private readonly activeRoute: ActivatedRoute,
               private readonly router: Router,
@@ -52,9 +53,6 @@ export class DetailsPageComponent implements OnInit, OnDestroy {
     this.activeRoute.paramMap.subscribe(params => {
       this.id = params.get('id');
       this.getDetailsFromId(this.id);
-      this.currentTransformationDescription = this.dataHandlerService.currentTransformation
-      && this.dataHandlerService.currentTransformation.description ?
-        this.dataHandlerService.currentTransformation.description : '';
     });
 
     this.categoryService.categories$.subscribe(categories => {

--- a/src/app/shared/data-handler.service.ts
+++ b/src/app/shared/data-handler.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpErrorResponse} from '@angular/common/http';
-import {EMPTY, Observable, throwError} from 'rxjs';
+import {BehaviorSubject, EMPTY, Observable, throwError} from 'rxjs';
 
 import { UserHandlerService } from '../shared/user/user-handler.service';
 import {
@@ -52,7 +52,9 @@ This will then handle errors and log them if the backend sends an error.
 })
 export class DataHandlerService {
 
-  currentTransformation?: ILineageTransformation;
+  private currentTransformation = new BehaviorSubject<ILineageTransformation>(null);
+  
+  currentTransformation$ = this.currentTransformation.asObservable();
   userLoggedIn$ = this.userHandlerService.userLoggedIn$;
 
   constructor(
@@ -185,7 +187,9 @@ export class DataHandlerService {
   }
 
   public setCurrentTransformation(transform: ILineageTransformation[]) {
-    this.currentTransformation = transform && transform.length ? transform[0] : undefined;
+    const currentTransformation = transform && transform.length ? transform[0] : undefined;
+
+    this.currentTransformation.next(currentTransformation);
   }
 
   public createCategory(createRequest: ICategoryCreateRequest): Observable<ICategory> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,8 @@
     ],
     "resolveJsonModule": true,
     "esModuleInterop": true
-  }
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true
+  },
 }


### PR DESCRIPTION
Enabled the strictTemplates option which makes the type checker much stronger and therefore able to catch many bugs at compile-time instead of encountering them at runtime.

This flaggede several errors in the code which are also fixed here