### PR TITLE
Improvements to preview feature

### DIFF
--- a/src/app/pages/details-page/details-page.component.ts
+++ b/src/app/pages/details-page/details-page.component.ts
@@ -131,9 +131,13 @@ export class DetailsPageComponent implements OnInit, OnDestroy {
         this.egressService.fetchAndShowPreviewData(this.dataSet.id, token, fromDate, toDate)
           .subscribe(previewDataDialogData => {
             this.previewButtonLoading = false;
-            this.dialog.open(PreviewDataComponent, {
-              data: previewDataDialogData
-            });
+            
+            if (previewDataDialogData !== null)
+            {
+              this.dialog.open(PreviewDataComponent, {
+                data: previewDataDialogData
+              });
+            }
           },
             _ => this.previewButtonLoading = false);
       } else {

--- a/src/app/shared/services/egress.service.ts
+++ b/src/app/shared/services/egress.service.ts
@@ -19,8 +19,8 @@ export class EgressService {
   public fetchAndShowPreviewData(datasetId: string, token: string, fromDate: Date, toDate: Date): Observable<PreviewDataDialogData> {
     const previewData = new ReplaySubject<PreviewDataDialogData>(1);
 
-    const toDateString = formatDate(toDate, 'yyyy-MM-ddTHH:mm', this.locale, 'UTC');
-    const fromDateString = formatDate(fromDate, 'yyyy-MM-ddTHH:mm', this.locale, 'UTC');
+    const toDateString = formatDate(toDate, 'yyyy-MM-dd', this.locale, 'UTC');
+    const fromDateString = formatDate(fromDate, 'yyyy-MM-dd', this.locale, 'UTC');
     const options = {
       headers: new HttpHeaders().set('X-Authorization', token),
       params: new HttpParams()
@@ -33,7 +33,7 @@ export class EgressService {
       .subscribe((result: any) => {
         if (!result || result.length === 0) {
           this.translator.get('details.side.access.preview.noData').subscribe(val => this.messageNotifier.sendMessage(val, false));
-          return;
+          return previewData.next(null);
         }
         const displayedColumns = Object.keys(result[0]);
         return previewData.next(new PreviewDataDialogData(displayedColumns, result));


### PR DESCRIPTION
This fixes an issue where the spinner would continue infinitely if the request was successful but there was no data.

Also by not including HH:mm in the 'to' and 'from' dates we fix most of the datasets that previously returned success but no data